### PR TITLE
Fixed Absolute Path Issue

### DIFF
--- a/src/nerdstorage/hash/hash.py
+++ b/src/nerdstorage/hash/hash.py
@@ -3,7 +3,7 @@ from getpass import getpass
 
 from werkzeug.security import generate_password_hash
 
-BASE_PATH = os.path.dirname(__file__)
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 try:
     password = getpass()


### PR DESCRIPTION
 - On Debian / Ubuntu based distros, os.path.dirname(__file__) would return an empty string, causing the hash process to fail.
 - This fix resolves this issue by fetching the absolute path before obtaining the directory name.